### PR TITLE
fix: dark mode for solution text (no-input questions)

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -9,6 +9,8 @@ only_build_toc_files: true
 html:
   favicon : "figures/TB_favicon.ico"
   baseurl :  "https://teachbooks.io/" #Replace this with your own URL
+  extra_css:
+  - custom.css
 
 sphinx:
   config:

--- a/book/_static/custom.css
+++ b/book/_static/custom.css
@@ -1,0 +1,8 @@
+
+/*
+Force p-elements in .jupyter-widgets to use the same color as the header-elements (like the question titles).
+Could alternatively use --pst-color-text-base so it matches the static p-elements in the book.
+*/
+.jupyter-widgets p {
+    color: var(--pst-color-muted)
+}


### PR DESCRIPTION
Dark mode now renders correctly for no-input
questions and it should also render correctly
for any p-elements rendered from ipython.display.

Overrides color to use the same as the one used
for headers.

Note: will not apply to no-input questions until
ForceoftheCyber/CyberBook#45 is resolved (uses h2-tags)