### PR TITLE
Use MathJax version 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ ipyquizjb
 ipysim
 micropip
 
-git+https://github.com/TeachBooks/Sphinx-Thebe
+# Uses a fork of Teachbooks' Sphinx-Thebe to use version 3 of MathJax
+git+https://github.com/ForceoftheCyber/Sphinx-Thebe


### PR DESCRIPTION
Changes to our fork of Sphinx-Thebe that uses MathJax version 3